### PR TITLE
Be/fix/user api

### DIFF
--- a/book/src/main/java/com/hd/book/controller/AuthController.java
+++ b/book/src/main/java/com/hd/book/controller/AuthController.java
@@ -72,7 +72,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponseDto> login(
+    public ResponseEntity<?> login(
             @RequestBody LoginRequestDto request
     ) {
         try {
@@ -100,14 +100,15 @@ public class AuthController {
 
             return ResponseEntity.ok(new LoginResponseDto(token, refreshToken, nickname));
         } catch (AuthenticationException ex) {
-            // 인증 실패
+            Map<String,String> body = Map.of("[ERROR]", "이메일 또는 비밀번호 불일치");
             return ResponseEntity
                     .status(HttpStatus.UNAUTHORIZED)
-                    .build();
+                    .body(body);
         } catch (Exception ex) {
+            log.error("로그인 처리 중 예외 발생", ex);    // <<< 여기서 스택트레이스 로깅
             return ResponseEntity
                     .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .build();
+                    .body(Map.of("[ERROR]", "내부 서버 오류 발생"));
         }
     }
 

--- a/book/src/main/java/com/hd/book/jwt/JwtUtil.java
+++ b/book/src/main/java/com/hd/book/jwt/JwtUtil.java
@@ -11,6 +11,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.security.Key;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 @Component
@@ -37,11 +41,20 @@ public class JwtUtil {
 
     // 액세스 토큰 생성
     public String generateToken(String userEmail) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() + accessTokenValidityInMs);
+        LocalDateTime now = LocalDateTime.now();
+        // 발행 시각 Instant 변환
+        Instant issuedAtInstant = now.atZone(ZoneId.systemDefault()).toInstant();
+        // 만료 시각 계산 (밀리초 단위)
+        Instant expiryInstant = now
+                .plus(accessTokenValidityInMs, ChronoUnit.MILLIS)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
+        Date issuedAt = Date.from(issuedAtInstant);
+        Date expiry   = Date.from(expiryInstant);
+
         return Jwts.builder()
                 .setSubject(userEmail)
-                .setIssuedAt(now)
+                .setIssuedAt(issuedAt)
                 .setExpiration(expiry)
                 .signWith(key)
                 .compact();
@@ -49,11 +62,19 @@ public class JwtUtil {
 
     // 리프레시 토큰 생성
     public String generateRefreshToken(String userEmail) {
-        Date now = new Date();
-        Date expiry = new Date(now.getTime() + refreshTokenValidityInMs);
+        LocalDateTime now = LocalDateTime.now();
+        Instant issuedAtInstant = now.atZone(ZoneId.systemDefault()).toInstant();
+        Instant expiryInstant = now
+                .plus(refreshTokenValidityInMs, ChronoUnit.MILLIS)
+                .atZone(ZoneId.systemDefault())
+                .toInstant();
+
+        Date issuedAt = Date.from(issuedAtInstant);
+        Date expiry   = Date.from(expiryInstant);
+
         return Jwts.builder()
                 .setSubject(userEmail)
-                .setIssuedAt(now)
+                .setIssuedAt(issuedAt)
                 .setExpiration(expiry)
                 .signWith(key)
                 .compact();

--- a/book/src/main/java/com/hd/book/repository/RefreshTokenRepository.java
+++ b/book/src/main/java/com/hd/book/repository/RefreshTokenRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshTokenEntity, Long> {
     Optional<RefreshTokenEntity> findByToken(String token);
 
-    int deleteByUser(UserEntity user);
+    void deleteByUser(UserEntity user);
 }

--- a/book/src/main/java/com/hd/book/service/RefreshTokenService.java
+++ b/book/src/main/java/com/hd/book/service/RefreshTokenService.java
@@ -20,12 +20,14 @@ public class RefreshTokenService {
     private final UserRepository userRepository;
 
     // 사용자 이메일로 리프레시 토큰을 생성하고 DB에 저장
+    @Transactional
     public RefreshTokenEntity createRefreshToken(String userEmail) {
         UserEntity user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다. : " + userEmail));
 
         // 기존에 발급된 리프레시 토큰이 있으면 삭제
         refreshTokenRepository.deleteByUser(user);
+        refreshTokenRepository.flush(); // 삭제 쿼리를 즉시 DB에 반영
 
         // 새로운 리프레쉬 토큰 문자열 생성
         String token = jwtUtil.generateRefreshToken(userEmail);
@@ -44,6 +46,7 @@ public class RefreshTokenService {
     }
 
     // 리프레시 토큰의 만료 여부 확인
+    @Transactional
     public RefreshTokenEntity verifyExpiration(RefreshTokenEntity tokenEntity) {
         // 만료 시각이 현재 시각 이전이면 토큰 만료
         if (tokenEntity.getExpiryDate().isBefore(Instant.now())) {


### PR DESCRIPTION
제목: BE/fix/user-api 브랜치 merge 요청

설명:

이 PR에서는 리프레시 토큰 관리 및 인증 흐름과 관련된 다음 네 가지 주요 개선 사항을 적용하였습니다:
	1.	리프레시 토큰 생성·검증 로직 개선
	•	RefreshTokenService.createRefreshToken() 및 verifyExpiration() 메서드에 @Transactional 애노테이션을 추가하고,
	•	deleteByUser() 호출 직후 flush()를 수행하여 기존 토큰 삭제가 즉시 DB에 반영되도록 하였습니다
（커밋 2599be6）
	2.	deleteByUser 반환 타입 변경
	•	파생 쿼리 메서드인 deleteByUser의 반환 타입을 int에서 void로 변경하여 코드 가독성을 높였습니다
（커밋 d3edcde）
	3.	로그인 실패 시 상세 오류 응답 및 예외 로깅 추가
	•	인증 실패 시 클라이언트에 명확한 에러 메시지를 JSON 바디로 반환하도록 수정하고,
	•	컨트롤러에서 예외 발생 시 스택트레이스를 로깅하도록 개선하였습니다
（커밋 4003033）
	4.	JWT 생성 로직 타임스탬프 개선
	•	LocalDateTime 기반으로 issuedAt 및 expiration 시점을 계산하도록 변경하여,
	•	시스템 로컬 타임존을 정확히 반영하도록 개선하였습니다
（커밋 326bb42）